### PR TITLE
Fix "Create the whitelist by IP" example

### DIFF
--- a/docs/v0.3.X/docs/write_configurations/whitelist.md
+++ b/docs/v0.3.X/docs/write_configurations/whitelist.md
@@ -75,15 +75,15 @@ $ {{v0X.cli.bin}} ban list
 
 ### Create the whitelist by IP
 
-Let's create a `/etc/crowdsec/crowdsec/parsers/s02-enrich/mywhitelists.yaml` file with the following content :
+Let's create a `/etc/crowdsec/parsers/s02-enrich/mywhitelists.yaml` file with the following content :
 
 ```yaml
 name: crowdsecurity/whitelists
 description: "Whitelist events from my ip addresses"
 whitelist:
   reason: "my ip ranges"
-    ip:
-        - "80.x.x.x"
+  ip:
+    - "80.x.x.x"
 ```
 
 and reload {{v0X.crowdsec.name}} : `sudo systemctl reload crowdsec`


### PR DESCRIPTION
Fix spacing and directory path for "Create the whitelist by IP" example